### PR TITLE
1주차 보고서

### DIFF
--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -5,10 +5,9 @@
 - [회의록 바로가기](https://docs.google.com/document/d/1gus4xQ854Sc9UpVQKPqUp_pA5Li2abAJ6lwOjiY4crg/edit?tab=t.0#heading=h.wafyrozcj9q3)
 
 2주차 일정부터 (11.03-) 각자 읽는 시간을 가질 예정이고, 시작 직전에 어떤 프로젝트 중에서 무엇을 목표로 읽을지 설정하고 공유
-
 매 회의마다 각자 읽는 동안 괴로웠던 지점이나 좋았던 부분을 공유하고, 직후 1시간정도 모두가 화면을 공유한 채로 독서 시간을 가질 예정
 
-각자 선정한 프로젝트와 이슈 (중간에 변동될 수 있음)
+## 각자 선정한 프로젝트와 이슈 (중간에 변동될 수 있음)
 
 **최승일**
 
@@ -26,7 +25,6 @@
 - 현재 리뷰를 기다리는 중 [PR](https://github.com/exercism/java/pull/2858)
 - 다음 프로젝트는 아래의 리스트에서 하나를 고를 생각
 - auth0 - [update the CI to run with java 21 and docs ](https://github.com/auth0/java-jwt/issues/690)
-
 - lombok - [Missed null checks in record constructor](https://github.com/projectlombok/lombok/issues/3743)
 
 **조인혁**

--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -1,0 +1,16 @@
+# 1주차 보고서
+
+1주차에는 회의를 통해 팀이 언제 어디서 모이고, 모여서 무엇을 하는지 설정
+
+- [회의록 바로가기](https://docs.google.com/document/d/1gus4xQ854Sc9UpVQKPqUp_pA5Li2abAJ6lwOjiY4crg/edit?tab=t.0#heading=h.wafyrozcj9q3)
+
+2주차 일정부터 (11.03-) 각자 읽는 시간을 가질 예정이고, 시작 직전에 어떤 프로젝트 중에서 무엇을 목표로 읽을지 설정하고 공유
+
+매 회의마다 각자 읽는 동안 괴로웠던 지점이나 좋았던 부분을 공유하고, 직후 1시간정도 모두가 화면을 공유한 채로 독서 시간을 가질 예정
+
+각자 선정한 프로젝트와 이슈 (중간에 변동될 수 있음)
+
+**최승일**
+
+- TanStack/query의 [bug report](https://github.com/TanStack/query/issues/8249)를 중심으로 읽어볼 예정
+- typescript로 쓰여진 부분이 꽤 있어 어느정도 ide의 도움을 기대 중

--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -14,3 +14,8 @@
 
 - TanStack/query의 [bug report](https://github.com/TanStack/query/issues/8249)를 중심으로 읽어볼 예정
 - typescript로 쓰여진 부분이 꽤 있어 어느정도 ide의 도움을 기대 중
+
+**문준호**
+
+- StackExchange.Redis에 [thread pool exhaustion 이슈가 있는 것으로 추정됨](https://github.com/StackExchange/StackExchange.Redis/issues/2812). 만약 이게 사실이라면 Issues에 올라온 대부분의 timeout 문제의 원인일 수 있음.
+- 회사에서 주로 사용하는 C# 코드라 읽을 수는 있을 것 같지만 .NET 기반 프로젝트가 아니라서 구조가 익숙하지 않음. 어떤 파일이 메인인지 파악하고 common use case에 대한 흐름을 캐치하는 것이 우선일 듯.

--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -28,3 +28,9 @@
 - auth0 - [update the CI to run with java 21 and docs ](https://github.com/auth0/java-jwt/issues/690)
 
 - lombok - [Missed null checks in record constructor](https://github.com/projectlombok/lombok/issues/3743)
+
+**조인혁**
+
+- [quartz](https://github.com/quartz-scheduler/quartz) 프로젝트의 [Do not consider a job as misfire when it is resumed after the server was in stand by mode](https://github.com/quartz-scheduler/quartz/issues/1117) 이슈를 확인할 예정
+- 이슈 해결에 앞서 이 프로젝트의 아키나 기능을 공부할 필요가 있음.
+- StandAlone으로 띄워서 기능을 알아봐야 할 듯

--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -19,3 +19,12 @@
 
 - StackExchange.Redis에 [thread pool exhaustion 이슈가 있는 것으로 추정됨](https://github.com/StackExchange/StackExchange.Redis/issues/2812). 만약 이게 사실이라면 Issues에 올라온 대부분의 timeout 문제의 원인일 수 있음.
 - 회사에서 주로 사용하는 C# 코드라 읽을 수는 있을 것 같지만 .NET 기반 프로젝트가 아니라서 구조가 익숙하지 않음. 어떤 파일이 메인인지 파악하고 common use case에 대한 흐름을 캐치하는 것이 우선일 듯.
+
+**이승재**
+
+- 미션 초반부는 오픈소스의 가이드와 규칙들을 파악하고 실제로 기여하는 것을 목표로 둠
+- 현재 리뷰를 기다리는 중  [PR](https://github.com/exercism/java/pull/2858) 
+- 다음 프로젝트는 아래의 리스트에서 하나를 고를 생각 
+- auth0 - [update the CI to run with java 21 and docs ](https://github.com/auth0/java-jwt/issues/690)
+
+- lombok - [Missed null checks in record constructor](https://github.com/projectlombok/lombok/issues/3743)

--- a/보고서/1주차.md
+++ b/보고서/1주차.md
@@ -6,7 +6,7 @@
 
 2주차 일정부터 (11.03-) 각자 읽는 시간을 가질 예정이고, 시작 직전에 어떤 프로젝트 중에서 무엇을 목표로 읽을지 설정하고 공유
 
-매 회의마다 각자 읽는 동안 괴로웠던 지점이나 좋았던 부분을 공유하고, 직후 1시간정도 모두가 화면을 공유한 채로 독서 시간을 가질 예정
+매 회의마다 각자 읽는 동안 괴로웠던 지점이나 좋았던 부분을 공유하고, 직후 1시간정도 모두가 화면을 공유한 채로 독서 시간을 가질 예정
 
 각자 선정한 프로젝트와 이슈 (중간에 변동될 수 있음)
 
@@ -23,8 +23,8 @@
 **이승재**
 
 - 미션 초반부는 오픈소스의 가이드와 규칙들을 파악하고 실제로 기여하는 것을 목표로 둠
-- 현재 리뷰를 기다리는 중  [PR](https://github.com/exercism/java/pull/2858) 
-- 다음 프로젝트는 아래의 리스트에서 하나를 고를 생각 
+- 현재 리뷰를 기다리는 중 [PR](https://github.com/exercism/java/pull/2858)
+- 다음 프로젝트는 아래의 리스트에서 하나를 고를 생각
 - auth0 - [update the CI to run with java 21 and docs ](https://github.com/auth0/java-jwt/issues/690)
 
 - lombok - [Missed null checks in record constructor](https://github.com/projectlombok/lombok/issues/3743)
@@ -34,3 +34,9 @@
 - [quartz](https://github.com/quartz-scheduler/quartz) 프로젝트의 [Do not consider a job as misfire when it is resumed after the server was in stand by mode](https://github.com/quartz-scheduler/quartz/issues/1117) 이슈를 확인할 예정
 - 이슈 해결에 앞서 이 프로젝트의 아키나 기능을 공부할 필요가 있음.
 - StandAlone으로 띄워서 기능을 알아봐야 할 듯
+
+**김진욱**
+
+- [Central Dogma](https://github.com/line/centraldogma)
+- 회사에서 쓰는 설정 관리 도구, 내부구조가 궁금해서 추가해 둠
+- [JsonPath bug in special character](https://github.com/line/centraldogma/issues/960)


### PR DESCRIPTION
# 1주차 보고서

1주차에는 회의를 통해 팀이 언제 어디서 모이고, 모여서 무엇을 하는지 설정

- [회의록 바로가기](https://docs.google.com/document/d/1gus4xQ854Sc9UpVQKPqUp_pA5Li2abAJ6lwOjiY4crg/edit?tab=t.0#heading=h.wafyrozcj9q3)

2주차 일정부터 (11.03-) 각자 읽는 시간을 가질 예정이고, 시작 직전에 어떤 프로젝트 중에서 무엇을 목표로 읽을지 설정하고 공유
매 회의마다 각자 읽는 동안 괴로웠던 지점이나 좋았던 부분을 공유하고, 직후 1시간정도 모두가 화면을 공유한 채로 독서 시간을 가질 예정

## 각자 선정한 프로젝트와 이슈 (중간에 변동될 수 있음)

**최승일**

- TanStack/query의 [bug report](https://github.com/TanStack/query/issues/8249)를 중심으로 읽어볼 예정
- typescript로 쓰여진 부분이 꽤 있어 어느정도 ide의 도움을 기대 중

**문준호**

- StackExchange.Redis에 [thread pool exhaustion 이슈가 있는 것으로 추정됨](https://github.com/StackExchange/StackExchange.Redis/issues/2812). 만약 이게 사실이라면 Issues에 올라온 대부분의 timeout 문제의 원인일 수 있음.
- 회사에서 주로 사용하는 C# 코드라 읽을 수는 있을 것 같지만 .NET 기반 프로젝트가 아니라서 구조가 익숙하지 않음. 어떤 파일이 메인인지 파악하고 common use case에 대한 흐름을 캐치하는 것이 우선일 듯.

**이승재**

- 미션 초반부는 오픈소스의 가이드와 규칙들을 파악하고 실제로 기여하는 것을 목표로 둠
- 현재 리뷰를 기다리는 중 [PR](https://github.com/exercism/java/pull/2858)
- 다음 프로젝트는 아래의 리스트에서 하나를 고를 생각
- auth0 - [update the CI to run with java 21 and docs ](https://github.com/auth0/java-jwt/issues/690)
- lombok - [Missed null checks in record constructor](https://github.com/projectlombok/lombok/issues/3743)

**조인혁**

- [quartz](https://github.com/quartz-scheduler/quartz) 프로젝트의 [Do not consider a job as misfire when it is resumed after the server was in stand by mode](https://github.com/quartz-scheduler/quartz/issues/1117) 이슈를 확인할 예정
- 이슈 해결에 앞서 이 프로젝트의 아키나 기능을 공부할 필요가 있음.
- StandAlone으로 띄워서 기능을 알아봐야 할 듯

**김진욱**

- [Central Dogma](https://github.com/line/centraldogma)
- 회사에서 쓰는 설정 관리 도구, 내부구조가 궁금해서 추가해 둠
- [JsonPath bug in special character](https://github.com/line/centraldogma/issues/960)
